### PR TITLE
Psalm tone tool improvements

### DIFF
--- a/psalms/007
+++ b/psalms/007
@@ -8,7 +8,6 @@ Et exsúrge, Dómine Deus meus, in præcépto quod mandásti : * et synagóga po
 Et propter hanc in altum regrédere : * Dóminus júdicat pópulos.
 Júdica me, Dómine, secúndum justítiam meam, * et secúndum innocéntiam meam super me.
 Consumétur nequítia peccatórum, et díriges justum, * scrutans corda et renes Deus.
-
 Justum adjutórium meum a Dómino, * qui salvos facit rectos corde.
 Deus judex justus, fortis, et pátiens : * numquid iráscitur per síngulos dies?
 Nisi convérsi fuéritis, gládium suum vibrábit : * arcum suum teténdit, et parávit illum.

--- a/psalms/033
+++ b/psalms/033
@@ -8,7 +8,6 @@ Immíttet Angelus Dómini in circúitu timéntium eum : * et erípiet eos.
 Gustáte, et vidéte quóniam suávis est Dóminus : * beátus vir, qui sperat in eo.
 Timéte Dóminum, omnes sancti ejus : * quóniam non est inópia timéntibus eum.
 Dívites eguérunt et esuriérunt : * inquiréntes autem Dóminum non minuéntur omni bono.
-
 Veníte, fílii, audíte me : * timórem Dómini docébo vos.
 Quis est homo qui vult vitam : * díligit dies vidére bonos?
 Próhibe linguam tuam a malo : * et lábia tua ne loquántur dolum.

--- a/psalms/102
+++ b/psalms/102
@@ -10,7 +10,6 @@ Non in perpétuum irascétur : * neque in ætérnum comminábitur.
 Non secúndum peccáta nostra fecit nobis : * neque secúndum iniquitátes nostras retríbuit nobis.
 Quóniam secúndum altitúdinem cæli a terra : * corroborávit misericórdiam suam super timéntes se.
 Quantum distat ortus ab occidénte : * longe fecit a nobis iniquitátes nostras.
-
 Quómodo miserétur pater filiórum, † misértus est Dóminus timéntibus se : * quóniam ipse cognóvit figméntum nostrum.
 Recordátus est quóniam pulvis sumus : † homo, sicut fœnum dies ejus, * tamquam flos agri sic efflorébit.
 Quóniam spíritus pertransíbit in illo, et non subsístet : * et non cognóscet ámplius locum suum.

--- a/psalmtone.htm
+++ b/psalmtone.htm
@@ -121,6 +121,7 @@ Mediant of <span id="sMedAccent"></span> accent<span id="sMedAccentS">s</span><s
 <tr class="bordered">
   <td>
     <label for="selFormat" title="Select a 'gabc' format to format all verses using gabc.&#10;New formats can be created with the 'Create New Format' button, and all formats can be edited using the panel to the right.">Format verses as: </label><select id="selFormat"></select><input type="button" id="btnDelFormat" value="Delete Current Format"/><input type="button" id="btnNewFormat" value="Create New Format"/><br/>
+    <input type="checkbox" id="cbInitStyle"/><label for="cbInitStyle" title="Use large drop cap for first verse, and ommit verse prefix on first verse.">Use initial style</label><br/>
     <input type="checkbox" id="cbOnlyVowels"/><label for="cbOnlyVowels" title="Only apply the formatting to the vowel rather than to the entire syllable, and only to first of any preparatory syllables rather than to all preparatory syllables.">Only format vowels</label><br/>
     <input type="checkbox" id="cbUsePunctaCava"/><label for="cbUsePunctaCava" title="Use a punctum cavum wherever a variable number of notes will be present depending on the specific verse.">Use puncta cava</label><br/>
     <input type="checkbox" id="cbRepeatIntonation"/><label for="cbRepeatIntonation" title="Repeat the intonation in each verse rather than just in the first verse (only affects the gabc output)">Repeat intonation</label><br/>

--- a/psalmtone.htm
+++ b/psalmtone.htm
@@ -118,46 +118,49 @@ Mediant of <span id="sMedAccent"></span> accent<span id="sMedAccentS">s</span><s
 <br/>Termination of <span id="sTermAccent"></span> accent<span id="sTermAccentS">s</span><span id="sTermPrepOuter"> with <span id="sTermPrep"></span> preperatory syllable<span id="sTermPrepS">s</span></span>
 </td><td><label for="selPsalm">Psalm </label><select id="selPsalm"></select> <input type="checkbox" id="cbUseNovaVulgata"/><label for="cbUseNovaVulgata">Use Nova Vulgata psalms</label> <input type="checkbox" id="cbIncludeGloriaPatri"/><label for="cbIncludeGloriaPatri">Include Glória Pátri</label><br/><div class="tap"><textarea id="versetext" lang="latin" style="height: 96pt; width: 100%;"></textarea></div>
 </td></tr>
-<tr class="bordered"><td>
-<label for="selFormat" title="Select a 'gabc' format to format all verses using gabc.&#10;New formats can be created with the 'Create New Format' button, and all formats can be edited using the panel to the right.">Format verses as: </label><select id="selFormat"></select><input type="button" id="btnDelFormat" value="Delete Current Format"/><input type="button" id="btnNewFormat" value="Create New Format"/>
-<br/><input type="checkbox" id="cbOnlyVowels"/><label for="cbOnlyVowels" title="Only apply the formatting to the vowel rather than to the entire syllable, and only to first of any preparatory syllables rather than to all preparatory syllables.">Only format vowels</label>
-<br/><input type="checkbox" id="cbUsePunctaCava"/><label for="cbUsePunctaCava" title="Use a punctum cavum wherever a variable number of notes will be present depending on the specific verse.">Use puncta cava</label>
-<br/><input type="checkbox" id="cbRepeatIntonation"/><label for="cbRepeatIntonation" title="Repeat the intonation in each verse rather than just in the first verse (only affects the gabc output)">Repeat intonation</label>
-<br/><label for="txtGabcStar" title="Text to use at the mediant if not a simple asterisk (*)">Asterisk Text:</label>&nbsp;<input type="text" id="txtGabcStar"/>
-</td><td style="border-left-style:solid;">
-<table class="">
-  <tr>
-    <td><label for="txtBeginPrep" title="This text will be added just before each preparatory syllable.">Begin Preparatory Syllable:</label></td>
-    <td><input type="text" id="txtBeginPrep"/></td>
-    <td style="padding-left:12pt;"><label for="txtEndPrep" title="This text will be added just after each preparatory syllable.">End Preparatory Syllable:</label></td>
-    <td><input type="text" id="txtEndPrep"/></td>
-  </tr>
-  <tr>
-    <td><label for="txtBeginAccented" title="This text will be added just before each accented syllable that figures in the mediant/termination.">Begin Accented Syllable:</label></td>
-    <td><input type="text" id="txtBeginAccented"/></td>
-    <td style="padding-left:12pt;"><label for="txtEndAccented" title="This text will be added just after each accented syllable that figures in the mediant/termination.">End Accented Syllable:</label></td>
-    <td><input type="text" id="txtEndAccented"/></td>
-  </tr>
-  <tr>
-    <td><label for="txtPrefix" title="Inserted before every verse.&#10;$c will be replaced by the verse number.&#10;&#10;If commas are present, it will cycle through each prefix in the comma separated list, e.g., '1,2,3' -> '1,2,3,1,2,etc.'">Verse Prefix:</label></td>
-    <td><input type="text" id="txtPrefix"/></td>
-    <td style="padding-left:12pt;"><label for="txtSuffix" title="Inserted after every verse.&#10;$c will be replaced by the verse number.">Verse Suffix:</label></td>
-    <td><input type="text" id="txtSuffix"/></td>
-  </tr>
-  <tr>
-    <td><label for="txtNbsp" title="Used before : * and † so that lines won't be broken up with one of these characters starting the line.">Non-breaking space:</label></td>
-    <td><input type="text" id="txtNbsp"/></td>
-    <td style="padding-left:12pt;"><label for="txtVersesName" title="Name of the verses file in Chrome when dragging the link to a file explorer window.  $psalm will be replaced with the psalm number (or Magnificat, etc.) and $tone will be replaced with the tone (e.g., 8gstar).">Verses Filename:</label></td>
-    <td><input type="text" id="txtVersesFilename"/></td>
-  </tr>
-  <tr>
-    <td><label for="txtAnnotation" title="This text will be added to the annotation field to show info such as the mode.">Annotation:</label></td>
-    <td><input type="text" id="txtAnnotation"/></td>
-    <td style="padding-left:12pt;" title="This text will be added to the user-notes field to show info such as the Psalm number."><label for="txtUserNotes">User Notes:</label></td>
-    <td><input type="text" id="txtUserNotes"/></td>
-  </tr>
-</table>
-</td></tr>
+<tr class="bordered">
+  <td>
+    <label for="selFormat" title="Select a 'gabc' format to format all verses using gabc.&#10;New formats can be created with the 'Create New Format' button, and all formats can be edited using the panel to the right.">Format verses as: </label><select id="selFormat"></select><input type="button" id="btnDelFormat" value="Delete Current Format"/><input type="button" id="btnNewFormat" value="Create New Format"/><br/>
+    <input type="checkbox" id="cbOnlyVowels"/><label for="cbOnlyVowels" title="Only apply the formatting to the vowel rather than to the entire syllable, and only to first of any preparatory syllables rather than to all preparatory syllables.">Only format vowels</label><br/>
+    <input type="checkbox" id="cbUsePunctaCava"/><label for="cbUsePunctaCava" title="Use a punctum cavum wherever a variable number of notes will be present depending on the specific verse.">Use puncta cava</label><br/>
+    <input type="checkbox" id="cbRepeatIntonation"/><label for="cbRepeatIntonation" title="Repeat the intonation in each verse rather than just in the first verse (only affects the gabc output)">Repeat intonation</label><br/>
+    <label for="txtGabcStar" title="Text to use at the mediant if not a simple asterisk (*)">Asterisk Text:</label>&nbsp;<input type="text" id="txtGabcStar"/>
+  </td>
+  <td style="border-left-style:solid;">
+    <table class="">
+      <tr>
+        <td><label for="txtBeginPrep" title="This text will be added just before each preparatory syllable.">Begin Preparatory Syllable:</label></td>
+        <td><input type="text" id="txtBeginPrep"/></td>
+        <td style="padding-left:12pt;"><label for="txtEndPrep" title="This text will be added just after each preparatory syllable.">End Preparatory Syllable:</label></td>
+        <td><input type="text" id="txtEndPrep"/></td>
+      </tr>
+      <tr>
+        <td><label for="txtBeginAccented" title="This text will be added just before each accented syllable that figures in the mediant/termination.">Begin Accented Syllable:</label></td>
+        <td><input type="text" id="txtBeginAccented"/></td>
+        <td style="padding-left:12pt;"><label for="txtEndAccented" title="This text will be added just after each accented syllable that figures in the mediant/termination.">End Accented Syllable:</label></td>
+        <td><input type="text" id="txtEndAccented"/></td>
+      </tr>
+      <tr>
+        <td><label for="txtPrefix" title="Inserted before every verse.&#10;$c will be replaced by the verse number.&#10;&#10;If commas are present, it will cycle through each prefix in the comma separated list, e.g., '1,2,3' -> '1,2,3,1,2,etc.'">Verse Prefix:</label></td>
+        <td><input type="text" id="txtPrefix"/></td>
+        <td style="padding-left:12pt;"><label for="txtSuffix" title="Inserted after every verse.&#10;$c will be replaced by the verse number.">Verse Suffix:</label></td>
+        <td><input type="text" id="txtSuffix"/></td>
+      </tr>
+      <tr>
+        <td><label for="txtNbsp" title="Used before : * and † so that lines won't be broken up with one of these characters starting the line.">Non-breaking space:</label></td>
+        <td><input type="text" id="txtNbsp"/></td>
+        <td style="padding-left:12pt;"><label for="txtVersesName" title="Name of the verses file in Chrome when dragging the link to a file explorer window.  $psalm will be replaced with the psalm number (or Magnificat, etc.) and $tone will be replaced with the tone (e.g., 8gstar).">Verses Filename:</label></td>
+        <td><input type="text" id="txtVersesFilename"/></td>
+      </tr>
+      <tr>
+        <td><label for="txtAnnotation" title="This text will be added to the annotation field to show info such as the mode.">Annotation:</label></td>
+        <td><input type="text" id="txtAnnotation"/></td>
+        <td style="padding-left:12pt;" title="This text will be added to the user-notes field to show info such as the Psalm number."><label for="txtUserNotes">User Notes:</label></td>
+        <td><input type="text" id="txtUserNotes"/></td>
+      </tr>
+    </table>
+  </td>
+</tr>
 </table>
 <div class="tap"><label for="editor" title="You can put GABC headers in this text box if you want them included in the GABC file download link below.  Any headers you type in will persist in local storage between sessions.">GABC</label><br/><textarea id="editor" spellcheck="false" style="height: 64px; width: 100%;"></textarea></div>
 <div style='margin:0.5em;'>

--- a/psalmtone.htm
+++ b/psalmtone.htm
@@ -126,17 +126,30 @@ Mediant of <span id="sMedAccent"></span> accent<span id="sMedAccentS">s</span><s
 <br/><label for="txtGabcStar" title="Text to use at the mediant if not a simple asterisk (*)">Asterisk Text:</label>&nbsp;<input type="text" id="txtGabcStar"/>
 </td><td style="border-left-style:solid;">
 <table class="">
-<tr><td><label for="txtBeginPrep" title="This text will be added just before each preparatory syllable.">Begin Preparatory Syllable:</label></td><td><input type="text" id="txtBeginPrep"/></td>
-<td style="padding-left:12pt;"><label for="txtEndPrep" title="This text will be added just after each preparatory syllable.">End Preparatory Syllable:</label></td><td><input type="text" id="txtEndPrep"/></td></tr>
-<tr><td><label for="txtBeginAccented" title="This text will be added just before each accented syllable that figures in the mediant/termination.">Begin Accented Syllable:</label></td><td><input type="text" id="txtBeginAccented"/></td>
-<td style="padding-left:12pt;"><label for="txtEndAccented" title="This text will be added just after each accented syllable that figures in the mediant/termination.">End Accented Syllable:</label></td><td><input type="text" id="txtEndAccented"/></td></tr>
-<tr><td><label for="txtPrefix" title="Inserted before every verse.&#10;$c will be replaced by the verse number.&#10;&#10;If commas are present, it will cycle through each prefix in the comma separated list, e.g., '1,2,3' -> '1,2,3,1,2,etc.'">Verse Prefix:</label></td>
-<td><input type="text" id="txtPrefix"/></td>
-<td style="padding-left:12pt;"><label for="txtSuffix" title="Inserted after every verse.&#10;$c will be replaced by the verse number.">Verse Suffix:</label></td>
-<td><input type="text" id="txtSuffix"/></td></tr>
-<tr><td><label for="txtNbsp" title="Used before : * and † so that lines won't be broken up with one of these characters starting the line.">Non-breaking space:</label></td><td><input type="text" id="txtNbsp"/></td>
-<td style="padding-left:12pt;"><label for="txtVersesName" title="Name of the verses file in Chrome when dragging the link to a file explorer window.  $psalm will be replaced with the psalm number (or Magnificat, etc.) and $tone will be replaced with the tone (e.g., 8gstar).">Verses Filename:</label></td><td><input type="text" id="txtVersesFilename"/></td>
-</tr>
+  <tr>
+    <td><label for="txtBeginPrep" title="This text will be added just before each preparatory syllable.">Begin Preparatory Syllable:</label></td>
+    <td><input type="text" id="txtBeginPrep"/></td>
+    <td style="padding-left:12pt;"><label for="txtEndPrep" title="This text will be added just after each preparatory syllable.">End Preparatory Syllable:</label></td>
+    <td><input type="text" id="txtEndPrep"/></td>
+  </tr>
+  <tr>
+    <td><label for="txtBeginAccented" title="This text will be added just before each accented syllable that figures in the mediant/termination.">Begin Accented Syllable:</label></td>
+    <td><input type="text" id="txtBeginAccented"/></td>
+    <td style="padding-left:12pt;"><label for="txtEndAccented" title="This text will be added just after each accented syllable that figures in the mediant/termination.">End Accented Syllable:</label></td>
+    <td><input type="text" id="txtEndAccented"/></td>
+  </tr>
+  <tr>
+    <td><label for="txtPrefix" title="Inserted before every verse.&#10;$c will be replaced by the verse number.&#10;&#10;If commas are present, it will cycle through each prefix in the comma separated list, e.g., '1,2,3' -> '1,2,3,1,2,etc.'">Verse Prefix:</label></td>
+    <td><input type="text" id="txtPrefix"/></td>
+    <td style="padding-left:12pt;"><label for="txtSuffix" title="Inserted after every verse.&#10;$c will be replaced by the verse number.">Verse Suffix:</label></td>
+    <td><input type="text" id="txtSuffix"/></td>
+  </tr>
+  <tr>
+    <td><label for="txtNbsp" title="Used before : * and † so that lines won't be broken up with one of these characters starting the line.">Non-breaking space:</label></td>
+    <td><input type="text" id="txtNbsp"/></td>
+    <td style="padding-left:12pt;"><label for="txtVersesName" title="Name of the verses file in Chrome when dragging the link to a file explorer window.  $psalm will be replaced with the psalm number (or Magnificat, etc.) and $tone will be replaced with the tone (e.g., 8gstar).">Verses Filename:</label></td>
+    <td><input type="text" id="txtVersesFilename"/></td>
+  </tr>
 </table>
 </td></tr>
 </table>

--- a/psalmtone.htm
+++ b/psalmtone.htm
@@ -150,6 +150,12 @@ Mediant of <span id="sMedAccent"></span> accent<span id="sMedAccentS">s</span><s
     <td style="padding-left:12pt;"><label for="txtVersesName" title="Name of the verses file in Chrome when dragging the link to a file explorer window.  $psalm will be replaced with the psalm number (or Magnificat, etc.) and $tone will be replaced with the tone (e.g., 8gstar).">Verses Filename:</label></td>
     <td><input type="text" id="txtVersesFilename"/></td>
   </tr>
+  <tr>
+    <td><label for="txtAnnotation" title="This text will be added to the annotation field to show info such as the mode.">Annotation:</label></td>
+    <td><input type="text" id="txtAnnotation"/></td>
+    <td style="padding-left:12pt;" title="This text will be added to the user-notes field to show info such as the Psalm number."><label for="txtUserNotes">User Notes:</label></td>
+    <td><input type="text" id="txtUserNotes"/></td>
+  </tr>
 </table>
 </td></tr>
 </table>

--- a/psalmtone.htm.js
+++ b/psalmtone.htm.js
@@ -259,21 +259,13 @@ function updateEnding() {
   updateEditor();
 }
 
-splitPsalms = {
-  "7"   : [10, 8],
-  "33"  : [10, 12],
-  "70"  : [13, 13],
-  "76"  : [12, 8],
-  "102" : [12, 10]
-}
-
 function getPsalms() {
   var r = Array();
   for(var i = 1; i <= 150; i++) {
     r.push(i);
-    if(i.toString() in splitPsalms)
+    if(i.toString() in splitPsalmsMap)
     {
-      for(var j = 0; j < splitPsalms[i.toString()].length; j++)
+      for(var j = 0; j < splitPsalmsMap[i.toString()].length; j++)
       {
         r.push(i + '.' + (j+1));
       }

--- a/psalmtone.htm.js
+++ b/psalmtone.htm.js
@@ -340,10 +340,12 @@ function updateFormat() {
   $("#txtEndPrep").val(f.italic[1]);
   $("#txtBeginAccented").val(f.bold[0]);
   $("#txtEndAccented").val(f.bold[1]);
-  $("#txtNbsp").val(f.nbsp);
-  $("#txtVersesFilename").val(f.versesName);
   $("#txtPrefix").val(f.verse[0]||"");
   $("#txtSuffix").val(f.verse[1]||"");
+  $("#txtNbsp").val(f.nbsp);
+  $("#txtVersesFilename").val(f.versesName);
+  $("#txtAnnotation").val(f.annotation);
+  $("#txtUserNotes").val(f.userNotes);
   updateEditor((JSON.stringify(gabcFormat) != JSON.stringify(oldGabcFormat)) || useFormat.match(/gabc(?=$|-)/) || oldFormat.match(/gabc(?=$|-)/));
 }
 function storeBiFormatsAndUpdate() {
@@ -366,6 +368,14 @@ function updateEndPrep() {
   bi_formats[useFormat].italic[1] = $("#txtEndPrep").val();
   storeBiFormatsAndUpdate();
 }
+function updatePrefix() {
+  bi_formats[useFormat].verse[0] = $("#txtPrefix").val();
+  storeBiFormatsAndUpdate();
+}
+function updateSuffix() {
+  bi_formats[useFormat].verse[1] = $("#txtSuffix").val();
+  storeBiFormatsAndUpdate();
+}
 function updateNbsp() {
   bi_formats[useFormat].nbsp = $("#txtNbsp").val();
   storeBiFormatsAndUpdate();
@@ -374,14 +384,12 @@ function updateVersesFilename(){
   bi_formats[useFormat].versesName = $("#txtVersesFilename").val();
   storeBiFormatsAndUpdate();
 }
-
-function updatePrefix() {
-  bi_formats[useFormat].verse[0] = $("#txtPrefix").val();
+function updateAnnotation() {
+  bi_formats[useFormat].annotation = $("#txtAnnotation").val();
   storeBiFormatsAndUpdate();
 }
-
-function updateSuffix() {
-  bi_formats[useFormat].verse[1] = $("#txtSuffix").val();
+function updateUserNotes(){
+  bi_formats[useFormat].userNotes = $("#txtUserNotes").val();
   storeBiFormatsAndUpdate();
 }
 
@@ -715,6 +723,8 @@ $(function() {
   $("#txtSuffix").keyup(updateSuffix);
   $("#txtNbsp").keyup(updateNbsp);
   $("#txtVersesFilename").keyup(updateVersesFilename);
+  $("#txtAnnotation").keyup(updateAnnotation);
+  $("#txtUserNotes").keyup(updateUserNotes);
   $("#txtClef").keyup(updateClef);
   $("#btnNewFormat").click(newFormat);
   $("#btnNewTone").click(newTone);

--- a/psalmtone.htm.js
+++ b/psalmtone.htm.js
@@ -517,6 +517,7 @@ function cancelZip(e){
   $("#lnkCancelZip").hide();
 }
 function annotationTextFormat(text,psalmNum,tone,ending){
+  var tone = tone.replace(/Introit /g,'');
   tone = tone + (ending ? ending : '');
   if(psalmNum.match(/\d+/)){
     psalmNum='Psalm ' + psalmNum;

--- a/psalmtone.htm.js
+++ b/psalmtone.htm.js
@@ -259,13 +259,28 @@ function updateEnding() {
   updateEditor();
 }
 
+splitPsalms = {
+  "7"   : [10, 8],
+  "33"  : [10, 12],
+  "70"  : [13, 13],
+  "76"  : [12, 8],
+  "102" : [12, 10]
+}
+
 function getPsalms() {
-  var r = Array(151);
-  for(var i=1; i <= 150; ++i) {
-    r[i-1] = i;
+  var r = Array();
+  for(var i = 1; i <= 150; i++) {
+    r.push(i);
+    if(i.toString() in splitPsalms)
+    {
+      for(var j = 0; j < splitPsalms[i.toString()].length; j++)
+      {
+        r.push(i + '.' + (j+1));
+      }
+    }
   }
-  r[150] = "Magnificat";
-  r[151] = "Benedictus"
+  r.push("Magnificat");
+  r.push("Benedictus");
   return r;
 }
 

--- a/psalmtone.htm.js
+++ b/psalmtone.htm.js
@@ -167,8 +167,16 @@ function updateEditor(forceGabcUpdate,_syl,_gSyl,_gShortMediant) {
     if(actuallyUpdate){
       filename = versesFilename(bi_formats[useFormat],$("#selPsalm").val(),$("#selTones").val(),$("#selEnd").val(),$("#cbSolemn")[0].checked)
       var header = getHeader(localStorage.psalmHeader||'');
-      header["initial-style"] = (useInitStyle) ? '1' : '0';
       header["name"] = filename.replace(/\.[^.]*$/,'');
+      header["initial-style"] = (useInitStyle) ? '1' : '0';
+      header["annotation"] = annotationTextFormat($("#txtAnnotation").val(),
+                                                  $("#selPsalm").val(),
+                                                  $("#selTones").val(),
+                                                  $("#selEnd").val());
+      header["user-notes"] = annotationTextFormat($("#txtUserNotes").val(),
+                                                  $("#selPsalm").val(),
+                                                  $("#selTones").val(),
+                                                  $("#selEnd").val());
       gabc=header+gabc;
       $("#editor").val(gabc);
       $("#editor").keyup();
@@ -508,15 +516,24 @@ function cancelZip(e){
   cancelZipping=true;
   $("#lnkCancelZip").hide();
 }
+function annotationTextFormat(text,psalmNum,tone,ending){
+  tone = tone + (ending ? ending : '');
+  if(psalmNum.match(/\d+/)){
+    psalmNum='Psalm ' + psalmNum;
+  }
+  psalmNum += '.';
+  return text.format({"psalm":psalmNum,
+                       "tone":tone});
+}
 function versesFilename(format,psalmNum,tone,ending,solemn){
   var tone = tone.replace(/\./g,'');
   var match = tone.match(/\d+/);
   if(match)tone=match[0];
   tone = (solemn?"solemn":"") + tone + (ending? ending.replace(/\*/,"star") : '');
-  return format && format.versesName?format.versesName.format(
+  return format && ((format.versesName) ? format.versesName.format(
     {"psalm":psalmNum,
       "tone":tone
-    }) : psalmNum + '-' + tone + ".txt";
+    }) : (psalmNum + '-' + tone + ".txt"));
 }
 function downloadAll(e){
   e.preventDefault();

--- a/psalmtone.htm.js
+++ b/psalmtone.htm.js
@@ -3,7 +3,7 @@ var custom_tones={};
 var gSyl,syl,_clef;
 var last_syl,last_gSyl,gShortMediant;
 var last_lines,last_terTones,last_medTones;
-var useFormat,onlyVowels,gabcFormat,usePunctaCava,repeatIntonation,italicizeIntonation,useNovaVulgata;
+var useFormat,useInitStyle,onlyVowels,gabcFormat,usePunctaCava,repeatIntonation,italicizeIntonation,useNovaVulgata;
 var includeGloriaPatri;
 function updateEditor(forceGabcUpdate,_syl,_gSyl,_gShortMediant) {
   var actuallyUpdate=(typeof(_syl)=="undefined");
@@ -78,6 +78,7 @@ function updateEditor(forceGabcUpdate,_syl,_gSyl,_gShortMediant) {
           gabc: gMediant,
           useOpenNotes: usePunctaCava,
           useBoldItalic: true,
+          firstPrefix: (!useInitStyle),
           onlyVowel: onlyVowels,
           format: gabcFormat,
           verseNumber: useNovaVulgata?"":i+1,
@@ -93,6 +94,7 @@ function updateEditor(forceGabcUpdate,_syl,_gSyl,_gShortMediant) {
             gabc: gTermination,
             useOpenNotes: usePunctaCava,
             useBoldItalic: true,
+            firstPrefix: (!useInitStyle),
             onlyVowel: onlyVowels,
             format: gabcFormat,
             verseNumber: useNovaVulgata?"":i+1,
@@ -127,6 +129,7 @@ function updateEditor(forceGabcUpdate,_syl,_gSyl,_gShortMediant) {
               gabc: getFlexGabc(medTones),
               useOpenNotes: false,
               useBoldItalic: false,
+              firstPrefix: true,
               onlyVowel: onlyVowels,
               format: gabcFormat
             });
@@ -154,6 +157,7 @@ function updateEditor(forceGabcUpdate,_syl,_gSyl,_gShortMediant) {
             gabc: removeIntonation($.extend(true,{},gTermination)),
             useOpenNotes: false,
             useBoldItalic: false,
+            firstPrefix: true,
             onlyVowel: onlyVowels,
             format:gabcFormat,
             favor: 'termination'
@@ -163,7 +167,7 @@ function updateEditor(forceGabcUpdate,_syl,_gSyl,_gShortMediant) {
     if(actuallyUpdate){
       filename = versesFilename(bi_formats[useFormat],$("#selPsalm").val(),$("#selTones").val(),$("#selEnd").val(),$("#cbSolemn")[0].checked)
       var header = getHeader(localStorage.psalmHeader||'');
-      header["initial-style"] = '0';
+      header["initial-style"] = (useInitStyle) ? '1' : '0';
       header["name"] = filename.replace(/\.[^.]*$/,'');
       gabc=header+gabc;
       $("#editor").val(gabc);
@@ -458,6 +462,10 @@ function deleteFormat() {
   }
 }
 
+function updateInitStyle() {
+  localStorage.cbInitStyle = useInitStyle = $("#cbInitStyle")[0].checked;
+  updateEditor(true);
+}
 function updateOnlyVowels() {
   localStorage.cbOnlyVowels = onlyVowels = $("#cbOnlyVowels")[0].checked;
   updateEditor(true);
@@ -693,6 +701,7 @@ $(function() {
   $("#selTones").change(updateEndings);
   $("#selTones").keyup(updateEndings);
   $("#cbSolemn").change(updateEnding);
+  $("#cbInitStyle").change(updateInitStyle);
   $("#cbOnlyVowels").change(updateOnlyVowels);
   $("#cbRepeatIntonation").change(updateRepeatIntonation);
   $("#cbItalicizeIntonation").change(updateItalicizeIntonation);
@@ -715,6 +724,7 @@ $(function() {
   $("#selPsalm").keyup(updatePsalm);
   $("#cbSolemn")[0].checked = ((hash.solemn || localStorage.cbSolemn) == "true");
   $("#cbOnlyVowels")[0].checked = onlyVowels = (localStorage.cbOnlyVowels == "true");
+  $("#cbInitStyle")[0].checked = useInitStyle = (localStorage.cbInitStyle != "false");
   $("#cbUsePunctaCava")[0].checked = usePunctaCava = (localStorage.cbUsePunctaCava != "false");
   $("#cbRepeatIntonation")[0].checked = repeatIntonation = (localStorage.cbRepeatIntonation == "true");
 //  $("#cbItalicizeIntonation")[0].checked = italicizeIntonation = (localStorage.cbItalicizeIntonation == "true");

--- a/psalmtone.js
+++ b/psalmtone.js
@@ -1014,6 +1014,7 @@ splitPsalmsMap = {
 };
 function slicePsalm(text,psalmNum,psalmPart){
   if(psalmPart>0){
+    psalmNum = Number(psalmNum).toString();
     var start = 0;
     for (var i = 0; i < psalmPart - 1; i ++)
     {

--- a/psalmtone.js
+++ b/psalmtone.js
@@ -1011,10 +1011,14 @@ splitPsalmsMap = {
   "70"  : [13, 13],
   "76"  : [12, 8],
   "102" : [12, 10]
-}
+};
 function slicePsalm(text,psalmNum,psalmPart){
   if(psalmPart>0){
-    var start = (splitPsalmsMap[psalmNum].slice(0,psalmPart-2)).reduce((a, b) => a + b);
+    var start = 0;
+    for (var i = 0; i < psalmPart - 1; i ++)
+    {
+      start += splitPsalmsMap[psalmNum][i];
+    }
     var end   = start + splitPsalmsMap[psalmNum][psalmPart-1];
     text = text.split('\n').slice(start, end).join('\n');
   }

--- a/psalmtone.js
+++ b/psalmtone.js
@@ -997,14 +997,6 @@ function addBoldItalic(text,accents,preparatory,sylsAfterBold,format,onlyVowel,v
     + result +
          ((suffix && suffix.replace(/\(([^$]*)\$c([^)]*)\)/gi,String(verseNum?("$1" + verseNum + "$2"):"")).replace(/\$c/gi,String(verseNum))) || "");
 }
-function normalizePsalm(text,includeGloriaPatri) {
-  text = text.replace(/\s+$/,'');
-  return includeGloriaPatri?
-      (text + "\n" + gloria_patri)
-    : text;
-}
-var _novaVulgata=null;
-var regexBaseNovaVulgata=["PSALMUS ","[^\\n]*\\n((?:\\S|(\\s+(?!PSALMUS \\d)))+)(?:\\s+PSALMUS|\\s*$)"];
 splitPsalmsMap = {
   "7"   : [10, 8],
   "33"  : [10, 12],
@@ -1012,7 +1004,7 @@ splitPsalmsMap = {
   "76"  : [12, 8],
   "102" : [12, 10]
 };
-function slicePsalm(text,psalmNum,psalmPart){
+function slicePsalm(text, psalmNum, psalmPart){
   if(psalmPart>0){
     psalmNum = Number(psalmNum).toString();
     var start = 0;
@@ -1025,6 +1017,12 @@ function slicePsalm(text,psalmNum,psalmPart){
   }
   return text;
 }
+function normalizePsalm(text, psalmNum, psalmPart, includeGloriaPatri) {
+  text = slicePsalm(text,psalmNum,psalmPart).replace(/\s+$/,'');
+  return includeGloriaPatri? (text + "\n" + gloria_patri) : text;
+}
+var _novaVulgata=null;
+var regexBaseNovaVulgata=["PSALMUS ","[^\\n]*\\n((?:\\S|(\\s+(?!PSALMUS \\d)))+)(?:\\s+PSALMUS|\\s*$)"];
 function getPsalm(psalmNum, includeGloriaPatri, useNovaVulgata, success) {
   var dotIdx    = psalmNum.indexOf('.');
   var psalmPart = 0;
@@ -1042,7 +1040,7 @@ function getPsalm(psalmNum, includeGloriaPatri, useNovaVulgata, success) {
       var regex=new RegExp(regexBaseNovaVulgata.join(psalmNum));
       var psalm = regex.exec(_novaVulgata);
       if(psalm) {
-        success(normalizePsalm(psalm[1],includeGloriaPatri));
+        success(normalizePsalm(psalm[1], psalmNum, psalmPart, includeGloriaPatri));
       } else {
         success("ERROR retrieving PSALMUS " + psalmNum);
       }
@@ -1069,15 +1067,15 @@ function getPsalm(psalmNum, includeGloriaPatri, useNovaVulgata, success) {
         }
         if(data && !calledSuccess) {
           calledSuccess=true;
-          success(normalizePsalm(data,includeGloriaPatri));
+          success(normalizePsalm(data, psalmNum, psalmPart, includeGloriaPatri));
         }
       },
       complete: function(jqXHR, textStatus) {
         if((t != undefined && t.responseText != undefined && t.responseText === "") || textStatus == "error") return;
-        var text = slicePsalm(t.responseText,psalmNum,psalmPart);
+        var text = t.responseText;
         if(!calledSuccess) {
           calledSuccess=true;
-          success(normalizePsalm(text,includeGloriaPatri));
+          success(normalizePsalm(text, psalmNum, psalmPart, includeGloriaPatri));
         }
       },
       dataType:"text"

--- a/psalmtone.js
+++ b/psalmtone.js
@@ -1012,6 +1012,14 @@ splitPsalmsMap = {
   "76"  : [12, 8],
   "102" : [12, 10]
 }
+function slicePsalm(text,psalmNum,psalmPart){
+  if(psalmPart>0){
+    var start = (splitPsalmsMap[psalmNum].slice(0,psalmPart-2)).reduce((a, b) => a + b);
+    var end   = start + splitPsalmsMap[psalmNum][psalmPart-1];
+    text = text.split('\n').slice(start, end).join('\n');
+  }
+  return text;
+}
 function getPsalm(psalmNum, includeGloriaPatri, useNovaVulgata, success) {
   var dotIdx    = psalmNum.indexOf('.');
   var psalmPart = 0;
@@ -1052,11 +1060,7 @@ function getPsalm(psalmNum, includeGloriaPatri, useNovaVulgata, success) {
           }
           data = temp.join(' ').replace(/\s*<br>\s*/g,"\n");
           if(data.charCodeAt(0) == 65279) data = data.slice(1);
-          if(psalmPart>0){
-            var start = sum(splitPsalmsMap[psalmNum].slice(0,psalmPart-2))
-            var end   = start + splitPsalmsMap[psalmNum][psalmPart-1];
-            data = data.split('\n').slice(start, end).join('\n');
-          }
+          data = slicePsalm(data,psalmNum,psalmPart);
         }
         if(data && !calledSuccess) {
           calledSuccess=true;
@@ -1065,7 +1069,7 @@ function getPsalm(psalmNum, includeGloriaPatri, useNovaVulgata, success) {
       },
       complete: function(jqXHR, textStatus) {
         if((t != undefined && t.responseText != undefined && t.responseText === "") || textStatus == "error") return;
-        var text = t.responseText;
+        var text = slicePsalm(t.responseText,psalmNum,psalmPart);
         if(!calledSuccess) {
           calledSuccess=true;
           success(normalizePsalm(text,includeGloriaPatri));

--- a/psalmtone.js
+++ b/psalmtone.js
@@ -426,6 +426,7 @@ function applyPsalmTone(options) {
       gabc = options.gabc,
       useOpenNotes = options.useOpenNotes || false,
       useBoldItalic = options.useBoldItalic || false,
+      firstPrefix = options.firstPrefix || false,
       onlyVowel = options.onlyVowel || false,
       format = options.format,
       verseNumber = options.verseNumber,
@@ -468,6 +469,10 @@ function applyPsalmTone(options) {
   var tmp = prefix.split(',');
   if(tmp.length>1 && tmp.slice(-1)[0].length>0) {
     prefix = tmp[typeof(verseNum)=='number'? (verseNum-1)%tmp.length : 0];
+  }
+  if(!firstPrefix && (Number(verseNum)==1))
+  {
+    prefix = "";
   }
   tmp = suffix.split(',');
   if(tmp.length>1 && tmp.slice(-1)[0].length>0) {

--- a/psalmtone.js
+++ b/psalmtone.js
@@ -1005,7 +1005,20 @@ function normalizePsalm(text,includeGloriaPatri) {
 }
 var _novaVulgata=null;
 var regexBaseNovaVulgata=["PSALMUS ","[^\\n]*\\n((?:\\S|(\\s+(?!PSALMUS \\d)))+)(?:\\s+PSALMUS|\\s*$)"];
+splitPsalmsMap = {
+  "7"   : [10, 8],
+  "33"  : [10, 12],
+  "70"  : [13, 13],
+  "76"  : [12, 8],
+  "102" : [12, 10]
+}
 function getPsalm(psalmNum, includeGloriaPatri, useNovaVulgata, success) {
+  var dotIdx    = psalmNum.indexOf('.');
+  var psalmPart = 0;
+  if (dotIdx > 0){
+    psalmPart = Number(psalmNum.slice(dotIdx+1));
+    psalmNum  = psalmNum.slice(0, dotIdx);
+  }
   if(useNovaVulgata){
     if(_novaVulgata==null){
       $.get("psalms/NovaVulgata.txt", function(data){
@@ -1039,6 +1052,11 @@ function getPsalm(psalmNum, includeGloriaPatri, useNovaVulgata, success) {
           }
           data = temp.join(' ').replace(/\s*<br>\s*/g,"\n");
           if(data.charCodeAt(0) == 65279) data = data.slice(1);
+          if(psalmPart>0){
+            var start = sum(splitPsalmsMap[psalmNum].slice(0,psalmPart-2))
+            var end   = start + splitPsalmsMap[psalmNum][psalmPart-1];
+            data = data.split('\n').slice(start, end).join('\n');
+          }
         }
         if(data && !calledSuccess) {
           calledSuccess=true;

--- a/psalmtone.js
+++ b/psalmtone.js
@@ -22,20 +22,75 @@ String.prototype.format = function(keys){
 }
 var o_bi_formats = 
     bi_formats = (function(){
-                  var _syl_subRegex= /ǽ/g;
-                  var _syl_substitutions= {'ǽ':"<sp>'ae</sp>"};
-                  return {
-                      html: {bold: ["<b>", "</b>"], italic: ["<i>", "</i>"],nbsp:"&nbsp;",verse: ["<span style='float:left;width:25pt;text-align:right;'>($c.)&nbsp;</span>","<br/>"],versesName:"$psalm-$tone.html"},
-                      tex: {bold:  ["{\\textbf{", "}"], italic:  ["{\\it ", "}"],nbsp:"~",verse:["\\item ",""],versesName:"$psalm-$tone.tex"},
-                      gabc: {bold: ["<b>", "</b>"], italic: ["<i>", "</i>"],nbsp:" ",verse:["($c. )",""],versesName:"$psalm-$tone.gabc",
+                    var _syl_subRegex= /ǽ/g;
+                    var _syl_substitutions= {'ǽ':"<sp>'ae</sp>"};
+                    return {
+                      html: {
+                        bold: ["<b>", "</b>"],
+                        italic: ["<i>", "</i>"],
+                        nbsp: "&nbsp;",
+                        verse: ["<span style='float:left;width:25pt;text-align:right;'>($c.)&nbsp;</span>","<br/>"],
+                        versesName: "$psalm-$tone.html",
+                        annotation: "$tone",
+                        userNotes: "$psalm"
+                      },
+                      tex: {
+                        bold: ["{\\textbf{", "}"],
+                        italic: ["{\\it ", "}"],
+                        nbsp: "~",
+                        verse: ["\\item ",""],
+                        versesName: "$psalm-$tone.tex",
+                        annotation: "$tone",
+                        userNotes: "$psalm"
+                      },
+                      gabc: {
+                        bold: ["<b>", "</b>"],
+                        italic: ["<i>", "</i>"],
+                        nbsp: " ",
+                        verse: ["($c. )",""],
+                        versesName: "$psalm-$tone.gabc",
                         makeSylSubstitutions: function(o){
                           return o? o.replace(_syl_subRegex,function(e){return _syl_substitutions[e]||e}) : o;
-                        }
+                        },
+                        annotation: "$tone",
+                        userNotes: "$psalm"
                       },
-                      "html-underline": {bold:["<u>","</u>"], italic:["<span style='border-bottom:3px double;'>","</span>"],nbsp:"&nbsp;",verse:["($c. )",""],versesName:"$psalm-$tone.html"},
-                      "tex-underline": {bold:["\\uline{","}"], italic:["\\uuline{","}"],nbsp:"~",verse:["($c. )",""],versesName:"$psalm-$tone.tex"},
-                      "gabc-plain": {bold:["",""],italic:["",""],nbsp:" ",verse:["($c. )",""],versesName:"$psalm-$tone.gabc"},
-                      "gabc-versicle": {bold:["",""],italic:["",""],nbsp:" ",verse:["<v>\\Vbar</v> ,<v>\\Rbar</v> ",""],versesName:"versicle.gabc"}
+                      "html-underline": {
+                        bold: ["<u>","</u>"],
+                        italic: ["<span style='border-bottom:3px double;'>","</span>"],
+                        nbsp: "&nbsp;",
+                        verse: ["($c. )",""],
+                        versesName: "$psalm-$tone.html",
+                        annotation: "$tone",
+                        userNotes: "$psalm"
+                      },
+                      "tex-underline": {
+                        bold: ["\\uline{","}"],
+                        italic: ["\\uuline{","}"],
+                        nbsp: "~",
+                        verse: ["($c. )",""],
+                        versesName: "$psalm-$tone.tex",
+                        annotation: "$tone",
+                        userNotes: "$psalm"
+                      },
+                      "gabc-plain": {
+                        bold: ["",""],
+                        italic: ["",""],
+                        nbsp: " ",
+                        verse: ["($c. )",""],
+                        versesName: "$psalm-$tone.gabc",
+                        annotation: "$tone",
+                        userNotes: "$psalm"
+                      },
+                      "gabc-versicle": {
+                        bold: ["",""],
+                        italic: ["",""],
+                        nbsp: " ",
+                        verse: ["<v>\\Vbar</v> ,<v>\\Rbar</v> ",""],
+                        versesName: "versicle.gabc",
+                        annotation: "$tone",
+                        userNotes: "$psalm"
+                      }
                     };
                 })();
 var o_g_tones = 


### PR DESCRIPTION
suggesting a few updates that I had wanted:

1. Split up psalms according to how they are used in the breviary. for instance instead of just selecting psalm 7, you can also select psalm 7.1 or 7.2.  This is determined by splitPsalmsMap.  Right now i just added the psalms for compline but the reset can be filled in.
2. added "use initial style" checkbox. when checked it uses the large first letter, and also removes the verse number on the first verse. When unchecked the styling is removed and the first verse number is added back.
3.  text box added to edit the annotation field. by default it will display the tone.
4. text box added to edit the user-notes field.  by default it will display the psalm number.

preview here: https://sethborders.github.io/jgabc/psalmtone.htm