### PR TITLE
Update transcriber.html.js

### DIFF
--- a/transcriber.html.js
+++ b/transcriber.html.js
@@ -122,7 +122,7 @@ function applyGabc(syl,gSyl,repeat,mapOffset,indexOffset) {
             cGabc={tones:elisionGabc.tones,gabc:'('+temp+')',index:cGabc.index+elisionGabc.tones.join('').length-temp.length};
           }
         } else {
-          result+='()';
+          //result+='()';
           --iG;
         }
       } else {


### PR DESCRIPTION
when I un-check 'use puncta for Elision', it still leaves space for the syllable adding extra hyphens
e.g cu _i_ becomes cu - _i_
it seems to be fixed if you just take out the empty parentheses