### PR TITLE
Update 1308.gabc

### DIFF
--- a/gabc/1308.gabc
+++ b/gabc/1308.gabc
@@ -1,8 +1,9 @@
-name:Speciosus... Eructavit;
-office-part:Graduale;
-mode:3;
-book:Graduale Romanum, 1961, p. 45 & The Liber Usualis, 1961, p. 434 & Graduale Romanum, 1974, p. 54 & Gregorian Missal, 1990, p. 214;
-transcriber:Andrew Hinkley;
+name: Speciosus... Eructavit;
+office-part: Graduale;
+mode: 3;
+book: Graduale Romanum, 1961, p. 45 & The Liber Usualis, 1961, p. 434 & Graduale Romanum, 1974, p. 54 & Gregorian Missal, 1990, p. 214;
+transcriber: Andrew Hinkley;
+commentary: Ps 44: 3, 2;
 %%
 (c3) SPe(e)ci(fhg)ó(h)sus(h.) *(,) for(hh//hhh.f!gwh/i_[oh:h]h//j_ijvIG)ma(ig/hi/jh) (,) (hhh'ih/ihhg.) (;) prae(fhg) fí(hihhf)li(hig)is(hiffe.) (,) hó(fhg/h_fi)mi(hg)num :(gv.eg/ihh/fgf.) (:) dif(f)fú(hf/ghg)sa(ge/f!hhhvFE'ec) est(d_e) (,) grá(eg)ti(g)a(fgF'Ef!hh/f!hhhvGF'hee[ll:1]d.0) (;) in(f) lá(hf/gh!ivFE')bi(feec)is(efe/f!hh) tu(gxfe/fgE'DefD'C)(,)(ef!hvvF'Eff//ef/ge)is.(c./eec//e[ll:1]d/ec..) (::) 
 <sp>V/</sp>. E(e)ru(e)ctá(e.f!gwhgh)vit(h_g) cor(g.h!iwjij) me(jihhf/ig/h_[oh:h]i_[oh:h]h_[oh:h])(,)(hhhvFEhg/h_i)um(ih/ihhg.) (;) ver(gh/iji/jhhg)bum(g) bo(h.f!gwh_g)num :(gv.eg/ihh/fgf.) (:) di(f)co(fi) e(ivvH'Fijhhgh)go(hg..) (;) ó(hv.fhg)pe(g)ra(g) me(gh/iji/jhhg)a(g.) (,) Re(h.f!gwh_g)gi :(gv.eg/ihh/fgf.) (:) lin(f)gua(f) me(f)a(f) cá(fgfg)la(ge/f!hhhvFE'ec)mus(d_e) (,) scri(eg)bae(fgF'Ef!hh/f!hhhvGF'hee[ll:1]d.0) (;) ve(f)ló(hf/gh!ivFE')ci(feec)ter(efef) (,) * scri(hh)bén(gxfe/fgE'DefD'C)(,)(ef!hvvF'Eff//ef/ge)tis.(c./eec//e[ll:1]d/ec..) (::)

--- a/gabc/1308.gabc
+++ b/gabc/1308.gabc
@@ -1,13 +1,8 @@
-name: Speciosus... Eructavit;
-office-part: Graduale;
-mode: 3;
-book: Graduale Romanum, 1961, p. 45 & The Liber Usualis, 1961, p. 434 & Graduale Romanum, 1974, p. 54 & Gregorian Missal, 1990, p. 214;
-transcriber: Andrew Hinkley;
-commentary: Ps 44: 3, 2;
+name:Speciosus... Eructavit;
+office-part:Graduale;
+mode:3;
+book:Graduale Romanum, 1961, p. 45 & The Liber Usualis, 1961, p. 434 & Graduale Romanum, 1974, p. 54 & Gregorian Missal, 1990, p. 214;
+transcriber:Andrew Hinkley;
 %%
-(c3) SPe(e)ci(fhg)ó(h)sus(h.) *(,) for([oh{]hh//hhh.f!gwh/i_h//j_ijvIG)ma(ig/hi/jh) (,) (hhh'ih/ihhg.) (;) præ(fhg) fí(hihhf)li(hig)is(hiffe.) (,) hó(fhg/h_fi)mi(hg)num:(gv.eg/ihh/fgf.) (:)
-dif(f)fú(hf/ghg)sa(ge/f!hhhvFE'ec) est(d_e) (,) grá(eg)ti(g)a(fgF'Ef!hh/f!hhhvGF'heed.0) (;) in(f) lá(hf/gh!ivFE')bi(feec)is(efe/f!hh) tu(gxfe/fgE'DefD'C)(,)(ef!hvvF'Eff//ef/ge)is.(c./eec//ed/ec..) (::)
-<sp>V/</sp>. E(e)ruc(e)tá(e.f!gwhgh)vit(h_g) cor(g.h!iwjij) me(jihhf/ig/h_i_h_)(,)(hhhvFEhg/h_i)um(ih/ihhg.) (;) ver(gh/iji/jhhg)bum(g) bo(h.f!gwh_g)num:(gv.eg/ihh/fgf.) (:)
-di(f)co(fi) e(ivvH'Fijhhgh)go(hg..) (;) ó(hv.fhg)pe(g)ra(g) me(gh/iji/jhhg)a(g.) (,) Re(h.f!gwh_g)gi:(gv.eg/ihh/fgf.) (:)
-lin(f)gua(f) me(f)a(f) cá(fgfg)la(ge/f!hhhvFE'ec)mus(d_e) (,) scri(eg)bæ(fgF'Ef!hh/f!hhhvGF'heed.0) (;) ve(f)ló(hf/gh!ivFE')ci(feec)ter(efef) *(,)
-scri(hh)bén(gxfe/fgE'DefD'C)(,)(ef!hvvF'Eff//ef/ge)tis.(c./eec//ed/ec..) (::)
+(c3) SPe(e)ci(fhg)ó(h)sus(h.) *(,) for(hh//hhh.f!gwh/i_[oh:h]h//j_ijvIG)ma(ig/hi/jh) (,) (hhh'ih/ihhg.) (;) prae(fhg) fí(hihhf)li(hig)is(hiffe.) (,) hó(fhg/h_fi)mi(hg)num :(gv.eg/ihh/fgf.) (:) dif(f)fú(hf/ghg)sa(ge/f!hhhvFE'ec) est(d_e) (,) grá(eg)ti(g)a(fgF'Ef!hh/f!hhhvGF'hee[ll:1]d.0) (;) in(f) lá(hf/gh!ivFE')bi(feec)is(efe/f!hh) tu(gxfe/fgE'DefD'C)(,)(ef!hvvF'Eff//ef/ge)is.(c./eec//e[ll:1]d/ec..) (::) 
+<sp>V/</sp>. E(e)ru(e)ctá(e.f!gwhgh)vit(h_g) cor(g.h!iwjij) me(jihhf/ig/h_[oh:h]i_[oh:h]h_[oh:h])(,)(hhhvFEhg/h_i)um(ih/ihhg.) (;) ver(gh/iji/jhhg)bum(g) bo(h.f!gwh_g)num :(gv.eg/ihh/fgf.) (:) di(f)co(fi) e(ivvH'Fijhhgh)go(hg..) (;) ó(hv.fhg)pe(g)ra(g) me(gh/iji/jhhg)a(g.) (,) Re(h.f!gwh_g)gi :(gv.eg/ihh/fgf.) (:) lin(f)gua(f) me(f)a(f) cá(fgfg)la(ge/f!hhhvFE'ec)mus(d_e) (,) scri(eg)bae(fgF'Ef!hh/f!hhhvGF'hee[ll:1]d.0) (;) ve(f)ló(hf/gh!ivFE')ci(feec)ter(efef) (,) * scri(hh)bén(gxfe/fgE'DefD'C)(,)(ef!hvvF'Eff//ef/ge)tis.(c./eec//e[ll:1]d/ec..) (::)


### PR DESCRIPTION
Cluster of neums on the second word (forma) when rendering. This was caught and corrected in GregoBase on 02 Aug 2023. I copied and replaced just the gabc section.