### PR TITLE
Fix English puncta cava update crash

### DIFF
--- a/psalmtone.js
+++ b/psalmtone.js
@@ -891,8 +891,9 @@ function applyPsalmTone(options) {
             --si;
             s = syl[si];
           }
-          if(s && useOpenNotes && openCount <= 1) {
-            r=processGabcPrespaceForWhitespace(syl[si+1].prespace)+lastOpen.gabc+r;
+          if(s && useOpenNotes && openCount <= 1 && typeof lastOpen === 'object') {
+            var nextSyl = syl[si + 1];
+            r=processGabcPrespaceForWhitespace((nextSyl && nextSyl.prespace) || "")+lastOpen.gabc+r;
           }
           lastOpen = undefined;
         } else if(!s.accent) {


### PR DESCRIPTION
Fixes a Psalm Tone Tool crash when `English` and `Use puncta cava` are enabled together.

In that path, `lastOpen` is not always a tone object, and there is not always a following syllable at `syl[si + 1]`. The update handler could then throw while reading `lastOpen.gabc` or `syl[si + 1].prespace`, leaving the GABC field and preview stale.

This keeps the carryover branch to the case it can handle and treats a missing next syllable as empty prespace.